### PR TITLE
Make skeleton to publish a python package.

### DIFF
--- a/claudius/__init__.py
+++ b/claudius/__init__.py
@@ -16,3 +16,5 @@ from .solve_prob import solve_prob
 
 from .calc_field import sc_field, tt_field
 from .far_field import far_field
+
+__version__ = "0.0.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = ["flit_core >=2,<4"]
+build-backend = "flit_core.buildapi"
+
+[tool.flit.metadata]
+module = "claudius"
+author = "Zoïs Moitier"
+author-email = "z.moitier@gmail.com"
+home-page = "https://pypi.org/project/claudius/"
+classifiers = ["License :: OSI Approved :: MIT License"]
+description-file = "README.md"
+requires-python = '>=3.7'
+requires = [
+    "numba", "numpy", "matplotlib", "scipy"
+]
+


### PR DESCRIPTION
Use flit, which is relatively simple for pure Python Packages

```
$ pip install flit

$ cd WHEREVER_CLAUDIUS_IS

$ flit init
Module name [claudius]:
Author : Zoïs Moitier
Author email : z.moitier@gmail.com
Home page [https://pypi.org/project/claudius/]:
Choose a license (see http://choosealicense.com/ for more info)
1. MIT - simple and permissive
2. Apache - explicitly grants patent rights
3. GPL - ensures that code based on this is shared with the same terms
4. Skip - choose a license later
Enter 1-4 [1]: 1

Written pyproject.toml; edit that file to add optional extra info.
$ git add pyproject.toml
```

Edit pyproject.toml and add the `requires-python` and `requires`
sections. Add also a `__version__` in `__init__.py` as this is where
flit pull the version number from.


--- 

From your machine, after having created a account on https://pypi.org/, you should have a file like

```
$ cat ~/.pypirc
[distutils]
index-servers =
    pypi

[pypi]
username: username
password: *******
```

you can then from the root of the repository do a 

```
 ~/dev/claudius[main ✓] $ flit build
Found 55 files tracked in git                                                                                                                                           I-flit.sdist
Writing generated setup.py                                                                                                                                              I-flit.sdist
Built sdist: dist/claudius-0.0.1.tar.gz                                                                                                                            I-flit_core.sdist
Copying package file(s) from /var/folders/ld/jy0c_5d91rl_s3jqh74tmqn00000gn/T/tmpahgktr38/claudius-0.0.1/claudius                                                  I-flit_core.wheel
Writing metadata files                                                                                                                                             I-flit_core.wheel
Writing the record of files                                                                                                                                        I-flit_core.wheel
Built wheel: dist/claudius-0.0.1-py3-none-any.whl                                                                                                                  I-flit_core.wheel
 ~/dev/claudius[main ✓] $ ls -al dist/*
-rw-------  1 bussonniermatthias  staff   18467 Nov 18 09:38 dist/claudius-0.0.1-py3-none-any.whl
-rw-r--r--  1 bussonniermatthias  staff  186331 Nov 18 09:38 dist/claudius-0.0.1.tar.gz
```

and 

```
$ flit publish
```

Will both build and upload on PyPI, then it's installable via `pip install claudius`. 
(bump __version__ and repeat as will for every new versions). 