### PR TITLE
Use pytest configuration file.

### DIFF
--- a/make_test_cov.sh
+++ b/make_test_cov.sh
@@ -1,1 +1,0 @@
-python3 -m pytest --cov=claudius --no-cov-on-fail tests/

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --cov=claudius --no-cov-on-fail --durations=10


### PR DESCRIPTION
tests/ is unnecessary. pytest will find tests on its own.
using pytest.ini is the more standard way to set pytest options; this
ensure that anybody that will run "pytest" will run with the right
options.

I also add the --durations=10 which will print the 10 slowest tests.

The test are currently relatively fast; but I encourage --ff (failed
first) that locally will rerun the last failing test first, and -x that
stop testing on first failure.