### PR TITLE
Use pytest configuration file.

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,0 +1,37 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Python package
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.7', '3.8']
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install pytest flit black isort
+        flit install 
+    - name: Reformat and checkk no diff was introduced.
+      run: |
+        bash ./format.sh
+        git diff --exit-code
+    - name: Test with pytest
+      run: |
+        pytest

--- a/make_test_cov.sh
+++ b/make_test_cov.sh
@@ -1,1 +1,0 @@
-python3 -m pytest --cov=claudius --no-cov-on-fail tests/

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --cov=claudius --no-cov-on-fail --durations=10


### PR DESCRIPTION
tests/ is unnecessary. pytest will find tests on its own.
using pytest.ini is the more standard way to set pytest options; this
ensure that anybody that will run "pytest" will run with the right
options.

I also add the --durations=10 which will print the 10 slowest tests.

The test are currently relatively fast; but I encourage --ff (failed
first) that locally will rerun the last failing test first, and -x that
stop testing on first failure.

-- 

On top of #3, so this actually only add the workflow file.